### PR TITLE
Better UI side websocket error handling

### DIFF
--- a/src/bp_logger/html/index.html
+++ b/src/bp_logger/html/index.html
@@ -483,7 +483,7 @@
         </div>
       </fieldset>
       <fieldset>
-        <legend>WiFi Networs</legend>
+        <legend>WiFi Networks</legend>
         <div>
           <table class="wifinetworks" id="wifinetworks">
             <tr><td class="ssid">My WiFi Network SSID</td><td>DEL</td></tr>


### PR DESCRIPTION
Just playing around with codebase and did some changes, just close this pull request if you don't like these changes 😂 

- Add valid check for websocket if its open before trying to send data
- Fix possible problem when websocket is closed and delete wifi button is pressed it getting stuck on disabled state
- Cleanup add wifi function and add proper error popup for invalid user input